### PR TITLE
v0.7.0: fixes for kamu-cli v0.226.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
+## [0.7.0] - 2025-02-25
+### Added
+- Support V6 layout of Kamu workspaces
+
 ## [0.6.1] - 2024-12-30
 ### Added
 - Ability to specify engine version via an environment variable

--- a/kamu/__init__.py
+++ b/kamu/__init__.py
@@ -2,7 +2,7 @@ import os
 
 from ._connection import KamuConnection
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"
 
 
 def connect(

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,21 +4,21 @@
 #
 #    pip-compile --extra=dev --extra=spark pyproject.toml
 #
-adbc-driver-flightsql==1.3.0
+adbc-driver-flightsql==1.4.0
     # via kamu (pyproject.toml)
-adbc-driver-manager==1.3.0
+adbc-driver-manager==1.4.0
     # via
     #   adbc-driver-flightsql
     #   kamu (pyproject.toml)
 astroid==3.3.8
     # via pylint
-black==24.10.0
+black==25.1.0
     # via kamu (pyproject.toml)
 build==1.2.2.post1
     # via
     #   kamu (pyproject.toml)
     #   pip-tools
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
 cffi==1.17.1
     # via cryptography
@@ -28,21 +28,23 @@ click==8.1.8
     # via
     #   black
     #   pip-tools
-cryptography==44.0.0
+cryptography==44.0.1
     # via secretstorage
 dill==0.3.9
     # via pylint
 docutils==0.21.2
     # via readme-renderer
-flake8==7.1.1
+flake8==7.1.2
     # via kamu (pyproject.toml)
+id==1.5.0
+    # via twine
 idna==3.10
     # via requests
-importlib-resources==6.4.5
+importlib-resources==6.5.2
     # via adbc-driver-flightsql
 iniconfig==2.0.0
     # via pytest
-isort==5.13.2
+isort==6.0.0
     # via
     #   kamu (pyproject.toml)
     #   pylint
@@ -68,7 +70,7 @@ mccabe==0.7.0
     #   pylint
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.5.0
+more-itertools==10.6.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -76,7 +78,7 @@ mypy-extensions==1.0.0
     # via black
 nh3==0.2.20
     # via readme-renderer
-numpy==2.2.1
+numpy==2.2.3
     # via pandas
 packaging==24.2
     # via
@@ -92,15 +94,13 @@ pathspec==0.12.1
     # via black
 pip-tools==7.4.1
     # via kamu (pyproject.toml)
-pkginfo==1.12.0
-    # via twine
 platformdirs==4.3.6
     # via
     #   black
     #   pylint
 pluggy==1.5.0
     # via pytest
-pyarrow==18.1.0
+pyarrow==19.0.1
     # via kamu (pyproject.toml)
 pycodestyle==2.12.1
     # via flake8
@@ -108,11 +108,11 @@ pycparser==2.22
     # via cffi
 pyflakes==3.2.0
     # via flake8
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   readme-renderer
     #   rich
-pylint==3.3.3
+pylint==3.3.4
     # via kamu (pyproject.toml)
 pyproject-hooks==1.2.0
     # via
@@ -122,12 +122,13 @@ pytest==8.3.4
     # via kamu (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via pandas
-pytz==2024.2
+pytz==2025.1
     # via pandas
 readme-renderer==44.0
     # via twine
 requests==2.32.3
     # via
+    #   id
     #   livy
     #   requests-toolbelt
     #   twine
@@ -143,11 +144,11 @@ six==1.17.0
     # via python-dateutil
 tomlkit==0.13.2
     # via pylint
-twine==6.0.1
+twine==6.1.0
     # via kamu (pyproject.toml)
 typing-extensions==4.12.2
     # via adbc-driver-manager
-tzdata==2024.2
+tzdata==2025.1
     # via pandas
 urllib3==2.3.0
     # via

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,7 @@ def workspace_mt(tempdir):
                       - accountName: kamu
                         isAdmin: true
                         avatarUrl: https://avatars.githubusercontent.com/u/50896974?s=200&v=4
+                        email: support+kamu@kamu.dev
                 """
             )
         )

--- a/tests/test_flight_sql.py
+++ b/tests/test_flight_sql.py
@@ -29,7 +29,7 @@ def server_flightsql_mt(workspace_mt):
 
 def pull_test_data(cwd):
     subprocess.run(
-        "kamu --account kamu pull odf+https://node.demo.kamu.dev/kamu/covid19.british-columbia.case-details.hm",
+        "kamu --account kamu pull odf+https://node.demo.kamu.dev/kamu/covid19.british-columbia.case-details.hm --visibility public",
         cwd=cwd,
         shell=True,
         capture_output=True,


### PR DESCRIPTION
Fixed 3 problems, caused with recent month updates in `kamu-cli`:
 - mandatory email for predefined accounts
 - pulling datasets is private by default, added visibility  switch to test routine
 - updated Livy connection to properly handle v6 workspace (after unification of storage laytout)